### PR TITLE
fix: replace --- with * * * in pr-plan to avoid YAML multi-doc separator

### DIFF
--- a/.github/workflows/pr-plan.yml
+++ b/.github/workflows/pr-plan.yml
@@ -168,7 +168,7 @@ ${fileRows}${truncNote}
 ### ✅ Review Checklist
 ${checks.join("\n")}
 
----
+* * *
 _Merge is blocked until CI passes. Update this checklist in a follow-up comment if needed._`;
 
             await github.rest.issues.createComment({


### PR DESCRIPTION
The \---\ inside the JavaScript template literal in \pr-plan.yml\ was being parsed by YAML tooling as a document separator (column 1 match). Replaced with \* * *\ which renders an identical Markdown horizontal rule.